### PR TITLE
Fix: Only download missing files with rsync

### DIFF
--- a/get_data.py
+++ b/get_data.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
     # + 12345 -   0   .  t x                 t 
     #---------------------------------------------
     #        [.-][t0][x.]t[x.]    *         [t8]
-    sp_args = ["rsync", "-am%s" % vstring,
+    sp_args = ["rsync", "--ignore-existing", "-am%s" % vstring,
                "--include", "*/",
                "--include", "[p123456789][g0123456789]%s[.-][t0][x.]t[x.]*[t8]" % args.pattern,
                "--exclude", "*",


### PR DESCRIPTION
I encountered an issue with the 'get_data.py' script re-downloading the files, and adding the `--ignore-existing` tag resolved the problem.

Consider including the `--times` flag, especially if there is a chance that files might be updated (although I am unsure if this is a possibility).

Hope that helps. Anyway, great work and thanks a lot!
Cheers.